### PR TITLE
Fixed missing BatchNorm and Activation before AveragePooling

### DIFF
--- a/wide_residual_network.py
+++ b/wide_residual_network.py
@@ -141,7 +141,10 @@ def create_wide_residual_network(input_dim, nb_classes=100, N=2, k=1, dropout=0.
     for i in range(N - 1):
         x = conv3_block(x, k, dropout)
         nb_conv += 2
-
+        
+    x = BatchNormalization(axis=channel_axis, momentum=0.1, epsilon=1e-5, gamma_initializer='uniform')(x)
+    x = Activation('relu')(x)
+    
     x = AveragePooling2D((8, 8))(x)
     x = Flatten()(x)
 


### PR DESCRIPTION
Just noticed today that a BatchNorm + Activation is missing after the last conv3_block (before the average_pooling).

```
for i in range(N - 1):
    x = conv3_block(x, k, dropout)
    nb_conv += 2
x = BatchNormalization(axis=channel_axis, momentum=0.1, epsilon=1e-5, gamma_initializer='uniform')(x)
x = Activation('relu')(x)
x = AveragePooling2D((8, 8))(x)
```
Cf. the [WRN-author's repo](https://github.com/szagoruyko/wide-residual-networks/blob/master/models/wide-resnet.lua#L99) and the corresponding [WRN-Graph](https://cloud.githubusercontent.com/assets/4953728/15483030/fc74ec0c-2132-11e6-9e1f-9bc03a83eeea.png).


Sidenote: I've also modified your code [here](https://github.com/ViaFerrata/DL_pipeline_TauAppearance/blob/master/HPC/cnns/models/wide_resnet.py#L76) in order to support both 2D & 3D if anyone has the same use case as me.