### PR TITLE
Fix to instantiate correct model depth

### DIFF
--- a/wide_residual_network.py
+++ b/wide_residual_network.py
@@ -120,7 +120,7 @@ def create_wide_residual_network(input_dim, nb_classes=100, N=2, k=1, dropout=0.
 
     x = expand_conv(x, 16, k)
 
-    for i in range(N - 1):
+    for i in range(N):
         x = conv1_block(x, k, dropout)
         nb_conv += 2
 
@@ -129,7 +129,7 @@ def create_wide_residual_network(input_dim, nb_classes=100, N=2, k=1, dropout=0.
 
     x = expand_conv(x, 32, k, strides=(2, 2))
 
-    for i in range(N - 1):
+    for i in range(N):
         x = conv2_block(x, k, dropout)
         nb_conv += 2
 
@@ -138,7 +138,7 @@ def create_wide_residual_network(input_dim, nb_classes=100, N=2, k=1, dropout=0.
 
     x = expand_conv(x, 64, k, strides=(2, 2))
 
-    for i in range(N - 1):
+    for i in range(N):
         x = conv3_block(x, k, dropout)
         nb_conv += 2
         


### PR DESCRIPTION
Fixed incorrect range() calls that resulted in creating models of depth (N-1)\*6 + 4 instead of the correct N\*6 + 4 depth.

Fixes issue #12 